### PR TITLE
Add reusable Button component and integrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# kolme11
+# Kolme React
+
+This repository contains the `kolme-react` project created with Vite and React 18. It uses React Router v6, Axios, and Bootstrap 5.
+
+The app includes authentication with the Context API, a global layout (header, sidebar, footer), protected routes, and example pages such as a dashboard and employee list. Components are written as functional components with hooks and use Bootstrap icons for UI elements.
+
+## Setup
+
+1. Install Node.js (latest LTS).
+2. Run `npm install` inside the `kolme-react` folder to install dependencies.
+3. Start the dev server with `npm start`.
+

--- a/kolme-react/index.html
+++ b/kolme-react/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kolme React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/kolme-react/package.json
+++ b/kolme-react/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "kolme-react",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "start": "vite"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1",
+    "axios": "^1.6.8",
+    "bootstrap": "^5.3.3",
+    "bootstrap-icons": "^1.11.3",
+    "react-toastify": "^9.1.3"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^4.5.0"
+  }
+}

--- a/kolme-react/src/App.jsx
+++ b/kolme-react/src/App.jsx
@@ -1,0 +1,38 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Layout from './components/layout/Layout';
+import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import EmployeeList from './pages/Employees/EmployeeList';
+import Roles from './pages/Roles';
+import Modules from './pages/Modules';
+import LeaveRequests from './pages/LeaveRequests';
+import ProtectedRoute from './components/common/ProtectedRoute';
+import { ToastContainer } from 'react-toastify';
+
+function App() {
+  return (
+    <>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/"
+          element={
+            <ProtectedRoute>
+              <Layout />
+            </ProtectedRoute>
+          }
+        >
+          <Route index element={<Dashboard />} />
+          <Route path="employees" element={<EmployeeList />} />
+          <Route path="roles" element={<Roles />} />
+          <Route path="modules" element={<Modules />} />
+          <Route path="leave-requests" element={<LeaveRequests />} />
+        </Route>
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+      <ToastContainer position="top-right" autoClose={3000} />
+    </>
+  );
+}
+
+export default App;

--- a/kolme-react/src/api.js
+++ b/kolme-react/src/api.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: '/api/',
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('token');
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+export default api;

--- a/kolme-react/src/components/common/Button.jsx
+++ b/kolme-react/src/components/common/Button.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function Button({
+  variant = 'primary',
+  size,
+  icon,
+  children,
+  className = '',
+  ...props
+}) {
+  const sizeClass = size ? `btn-${size}` : '';
+  return (
+    <button className={`btn btn-${variant} ${sizeClass} rounded ${className}`} {...props}>
+      {icon && <i className={`bi bi-${icon} me-1`} aria-hidden="true"></i>}
+      {children}
+    </button>
+  );
+}
+
+

--- a/kolme-react/src/components/common/FormInput.jsx
+++ b/kolme-react/src/components/common/FormInput.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+export default function FormInput({ label, icon, type = 'text', value, onChange, required, pattern, ...rest }) {
+  const [touched, setTouched] = useState(false);
+  const id = label.replace(/\s+/g, '-').toLowerCase();
+  const valid = !required || (value && (!pattern || new RegExp(pattern).test(value)));
+
+  return (
+    <div className="mb-3">
+      <label htmlFor={id} className="form-label">
+        {label} {required && <span className="text-danger">*</span>}
+      </label>
+      <div className="input-group">
+        {icon && (
+          <span className="input-group-text">
+            <i className={`bi bi-${icon}`} aria-hidden="true"></i>
+          </span>
+        )}
+        <input
+          id={id}
+          type={type}
+          className={`form-control${touched && !valid ? ' is-invalid' : ''}`}
+          value={value}
+          onBlur={() => setTouched(true)}
+          onChange={(e) => onChange(e.target.value)}
+          required={required}
+          pattern={pattern}
+          aria-invalid={!valid}
+          {...rest}
+        />
+        {touched && !valid && (
+          <div className="invalid-feedback">Please enter a valid {label.toLowerCase()}.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/kolme-react/src/components/common/Modal.jsx
+++ b/kolme-react/src/components/common/Modal.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef } from 'react';
+
+export default function Modal({ show, title, children, onClose, footer }) {
+  const dialogRef = useRef(null);
+
+  useEffect(() => {
+    if (show) {
+      document.body.classList.add('modal-open');
+      const lastFocused = document.activeElement;
+      const focusDialog = () => {
+        const el = dialogRef.current;
+        if (el) el.focus();
+      };
+      focusDialog();
+      const handleKey = (e) => {
+        if (e.key === 'Escape') onClose();
+        if (e.key === 'Tab') {
+          const focusable = dialogRef.current.querySelectorAll(
+            'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+          );
+          const first = focusable[0];
+          const last = focusable[focusable.length - 1];
+          if (e.shiftKey ? document.activeElement === first : document.activeElement === last) {
+            e.preventDefault();
+            (e.shiftKey ? last : first).focus();
+          }
+        }
+      };
+      const el = dialogRef.current;
+      el.addEventListener('keydown', handleKey);
+      return () => {
+        el.removeEventListener('keydown', handleKey);
+        lastFocused && lastFocused.focus();
+        document.body.classList.remove('modal-open');
+      };
+    }
+  }, [show, onClose]);
+
+  if (!show) return null;
+
+  return (
+    <div className="modal d-block" tabIndex="-1" role="dialog" aria-modal="true">
+      <div
+        className="modal-dialog modal-dialog-centered modal-lg modal-fullscreen-sm-down"
+        ref={dialogRef}
+      >
+        <div className="modal-content">
+          <div className="modal-header">
+            <h5 className="modal-title" id="modal-title">{title}</h5>
+            <button type="button" className="btn-close" aria-label="Close" onClick={onClose}></button>
+          </div>
+          <div className="modal-body">{children}</div>
+          {footer && <div className="modal-footer">{footer}</div>}
+        </div>
+      </div>
+      <div className="modal-backdrop fade show" onClick={onClose}></div>
+    </div>
+  );
+}

--- a/kolme-react/src/components/common/ProtectedRoute.jsx
+++ b/kolme-react/src/components/common/ProtectedRoute.jsx
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import { AuthContext } from '../../contexts/AuthContext';
+
+export default function ProtectedRoute({ children }) {
+  const { token } = useContext(AuthContext);
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children ? children : <Outlet />;
+}

--- a/kolme-react/src/components/common/Spinner.jsx
+++ b/kolme-react/src/components/common/Spinner.jsx
@@ -1,0 +1,7 @@
+export default function Spinner() {
+  return (
+    <div className="d-flex justify-content-center py-5" aria-label="Loading">
+      <div className="spinner-border" role="status" aria-hidden="true"></div>
+    </div>
+  );
+}

--- a/kolme-react/src/components/common/Table.jsx
+++ b/kolme-react/src/components/common/Table.jsx
@@ -1,0 +1,33 @@
+export default function Table({ columns, data, actions, className = '' }) {
+  return (
+    <div className="table-responsive" style={{ maxHeight: '400px' }}>
+      <table className={`table table-striped table-hover ${className}`}>
+        <thead className="table-light position-sticky top-0">
+          <tr>
+            {columns.map((c) => (
+              <th key={c.key} scope="col">
+                {c.label}
+                {c.info && (
+                  <i className="bi bi-info-circle ms-1" title={c.info} aria-label={c.info}></i>
+                )}
+              </th>
+            ))}
+            {actions && <th className="text-end">Actions</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row) => (
+            <tr key={row.id}>
+              {columns.map((c) => (
+                <td key={c.key} title={row[c.key]} className="text-truncate">
+                  {row[c.key]}
+                </td>
+              ))}
+              {actions && <td className="text-end">{actions(row)}</td>}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/kolme-react/src/components/common/ToastMessage.jsx
+++ b/kolme-react/src/components/common/ToastMessage.jsx
@@ -1,0 +1,7 @@
+import { toast } from 'react-toastify';
+
+export function showToast(msg, type = 'info') {
+  toast[msg.type ? msg.type : type](msg.text || msg, { toastId: msg.id });
+}
+
+export const Toast = () => null; // component placeholder

--- a/kolme-react/src/components/layout/Breadcrumbs.jsx
+++ b/kolme-react/src/components/layout/Breadcrumbs.jsx
@@ -1,0 +1,26 @@
+import { Link, useLocation } from 'react-router-dom';
+
+export default function Breadcrumbs() {
+  const location = useLocation();
+  const parts = location.pathname.split('/').filter(Boolean);
+  const crumbs = parts.map((part, idx) => {
+    const path = '/' + parts.slice(0, idx + 1).join('/');
+    const label = part.replace('-', ' ');
+    return { path, label };
+  });
+
+  return (
+    <nav aria-label="breadcrumb" className="bg-light px-3 py-2 border-bottom">
+      <ol className="breadcrumb mb-0">
+        <li className="breadcrumb-item">
+          <Link to="/">Home</Link>
+        </li>
+        {crumbs.map((c, i) => (
+          <li key={c.path} className={`breadcrumb-item ${i === crumbs.length - 1 ? 'active' : ''}`} aria-current={i === crumbs.length - 1 ? 'page' : undefined}>
+            {i === crumbs.length - 1 ? c.label : <Link to={c.path}>{c.label}</Link>}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/kolme-react/src/components/layout/Footer.jsx
+++ b/kolme-react/src/components/layout/Footer.jsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="bg-dark text-white text-center py-2 mt-auto">
+      <small>&copy; 2025 Kolme</small>
+    </footer>
+  );
+}

--- a/kolme-react/src/components/layout/Header.jsx
+++ b/kolme-react/src/components/layout/Header.jsx
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { AuthContext } from '../../contexts/AuthContext';
+
+export default function Header() {
+  const { logout } = useContext(AuthContext);
+  return (
+    <header className="navbar navbar-dark bg-dark text-white px-3">
+      <span className="navbar-brand mb-0 h1">Kolme</span>
+      <div className="ms-auto">
+        <button className="btn btn-sm btn-outline-light" onClick={logout} aria-label="Logout">
+          <i className="bi bi-box-arrow-right me-1"></i>
+          Logout
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/kolme-react/src/components/layout/Layout.jsx
+++ b/kolme-react/src/components/layout/Layout.jsx
@@ -1,0 +1,21 @@
+import { Outlet } from 'react-router-dom';
+import Header from './Header';
+import Sidebar from './Sidebar';
+import Footer from './Footer';
+import Breadcrumbs from './Breadcrumbs';
+
+export default function Layout() {
+  return (
+    <div className="d-flex flex-column min-vh-100">
+      <Header />
+      <Breadcrumbs />
+      <div className="d-flex flex-grow-1">
+        <Sidebar />
+        <main className="flex-grow-1 p-3 bg-white">
+          <Outlet />
+        </main>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/kolme-react/src/components/layout/Sidebar.jsx
+++ b/kolme-react/src/components/layout/Sidebar.jsx
@@ -1,0 +1,40 @@
+import { NavLink } from 'react-router-dom';
+import { useState } from 'react';
+
+export default function Sidebar() {
+  const [open, setOpen] = useState(true);
+  return (
+    <nav className={`bg-dark text-white sidebar ${open ? 'open' : 'collapsed'}`}>
+      <button className="btn btn-dark w-100 d-md-none" onClick={() => setOpen(!open)} aria-label="Toggle navigation">
+        <i className="bi bi-list"></i>
+      </button>
+      <ul className="nav flex-column mt-3">
+        <li className="nav-item">
+          <NavLink to="/" end className="nav-link text-white">
+            <i className="bi bi-speedometer2 me-2"></i>Dashboard
+          </NavLink>
+        </li>
+        <li className="nav-item">
+          <NavLink to="/employees" className="nav-link text-white">
+            <i className="bi bi-people me-2"></i>Employees
+          </NavLink>
+        </li>
+        <li className="nav-item">
+          <NavLink to="/roles" className="nav-link text-white">
+            <i className="bi bi-shield-lock me-2"></i>Roles
+          </NavLink>
+        </li>
+        <li className="nav-item">
+          <NavLink to="/modules" className="nav-link text-white">
+            <i className="bi bi-box-seam me-2"></i>Modules
+          </NavLink>
+        </li>
+        <li className="nav-item">
+          <NavLink to="/leave-requests" className="nav-link text-white">
+            <i className="bi bi-calendar-check me-2"></i>Leave Requests
+          </NavLink>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/kolme-react/src/contexts/AuthContext.jsx
+++ b/kolme-react/src/contexts/AuthContext.jsx
@@ -1,0 +1,24 @@
+import { createContext, useState, useEffect } from 'react';
+
+export const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [token, setToken] = useState(localStorage.getItem('token'));
+
+  useEffect(() => {
+    if (token) {
+      localStorage.setItem('token', token);
+    } else {
+      localStorage.removeItem('token');
+    }
+  }, [token]);
+
+  const login = (tok) => setToken(tok);
+  const logout = () => setToken(null);
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/kolme-react/src/main.jsx
+++ b/kolme-react/src/main.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import { AuthProvider } from './contexts/AuthContext';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap-icons/font/bootstrap-icons.css';
+import './styles/custom.css';
+import 'react-toastify/dist/ReactToastify.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/kolme-react/src/pages/Dashboard.jsx
+++ b/kolme-react/src/pages/Dashboard.jsx
@@ -1,0 +1,27 @@
+export default function Dashboard() {
+  const cards = [
+    { color: 'success', icon: 'check-circle', title: 'Approved', value: 12 },
+    { color: 'warning', icon: 'exclamation-triangle', title: 'Pending', value: 5 },
+    { color: 'danger', icon: 'x-circle', title: 'Rejected', value: 2 },
+  ];
+  return (
+    <div className="container-fluid">
+      <h1 className="my-4 border-bottom pb-2">Dashboard</h1>
+      <div className="row g-3">
+        {cards.map((c) => (
+          <div key={c.title} className="col-12 col-md-4">
+            <div className={`card text-white bg-${c.color}`}>
+              <div className="card-body d-flex align-items-center">
+                <i className={`bi bi-${c.icon} display-6 me-3`}></i>
+                <div>
+                  <h5 className="card-title mb-0">{c.title}</h5>
+                  <p className="card-text fs-4">{c.value}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/kolme-react/src/pages/Employees/EmployeeList.jsx
+++ b/kolme-react/src/pages/Employees/EmployeeList.jsx
@@ -1,0 +1,225 @@
+import { useEffect, useState } from 'react';
+import Table from '../../components/common/Table';
+import FormInput from '../../components/common/FormInput';
+import Modal from '../../components/common/Modal';
+import Spinner from '../../components/common/Spinner';
+import Button from '../../components/common/Button';
+import { showToast } from '../../components/common/ToastMessage';
+
+export default function EmployeeList() {
+  const [employees, setEmployees] = useState([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [page, setPage] = useState(1);
+  const pageSize = 5;
+
+  const [current, setCurrent] = useState({ id: null, name: '', email: '', phone: '' });
+  const [showForm, setShowForm] = useState(false);
+  const [showDelete, setShowDelete] = useState(false);
+  const [showView, setShowView] = useState(false);
+
+  useEffect(() => {
+    // simulate API
+    setTimeout(() => {
+      try {
+        setEmployees([
+          { id: 1, name: 'Alice Johnson', email: 'alice@example.com', phone: '1234567890' },
+          { id: 2, name: 'Bob Smith', email: 'bob@example.com', phone: '9876543210' },
+        ]);
+        setLoading(false);
+      } catch (err) {
+        setError('Failed to load');
+        setLoading(false);
+      }
+    }, 300);
+  }, []);
+
+  const filtered = employees.filter((e) =>
+    e.name.toLowerCase().includes(search.toLowerCase())
+  );
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const paginated = filtered.slice((page - 1) * pageSize, page * pageSize);
+
+  const openAdd = () => {
+    setCurrent({ id: null, name: '', email: '', phone: '' });
+    setShowForm(true);
+  };
+  const openEdit = (emp) => {
+    setCurrent(emp);
+    setShowForm(true);
+  };
+  const saveEmployee = () => {
+    if (current.id) {
+      setEmployees((prev) => prev.map((e) => (e.id === current.id ? current : e)));
+      showToast('Employee updated', 'success');
+    } else {
+      setEmployees((prev) => [...prev, { ...current, id: Date.now() }]);
+      showToast('Employee added', 'success');
+    }
+    setShowForm(false);
+  };
+  const confirmDelete = (emp) => {
+    setCurrent(emp);
+    setShowDelete(true);
+  };
+  const deleteEmployee = () => {
+    setEmployees((prev) => prev.filter((e) => e.id !== current.id));
+    setShowDelete(false);
+    showToast('Employee deleted', 'info');
+  };
+
+  const columns = [
+    { key: 'name', label: 'Name', info: 'Employee full name' },
+    { key: 'email', label: 'Email', info: 'Email address' },
+    { key: 'phone', label: 'Phone', info: '10 digit phone number' },
+  ];
+
+  if (loading) return <Spinner />;
+  if (error) return (
+    <div className="alert alert-danger" role="alert">
+      {error}
+      <Button
+        variant="light"
+        size="sm"
+        className="ms-2"
+        onClick={() => window.location.reload()}
+        aria-label="Retry"
+      >
+        Retry
+      </Button>
+    </div>
+  );
+  if (!employees.length)
+    return (
+      <div className="text-center py-5">
+        <i className="bi bi-people display-6 d-block mb-3" aria-hidden="true"></i>
+        <p>No employees found</p>
+        <Button variant="primary" onClick={openAdd} aria-label="Add Employee" icon="plus-lg">
+          Add
+        </Button>
+      </div>
+    );
+
+  return (
+    <div className="container-fluid">
+      <div className="d-flex justify-content-between align-items-center my-4 border-bottom pb-2">
+        <h1 className="mb-0">Employees</h1>
+        <Button variant="primary" onClick={openAdd} aria-label="Add Employee" icon="plus-lg">
+          Add
+        </Button>
+      </div>
+      <div className="mb-3">
+        <div className="input-group">
+          <span className="input-group-text"><i className="bi bi-search" aria-hidden="true"></i></span>
+          <input
+            type="text"
+            className="form-control"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search employees"
+          />
+        </div>
+      </div>
+      <Table
+        columns={columns}
+        data={paginated}
+        className="table-card"
+        actions={(e) => (
+          <>
+            <Button
+              size="sm"
+              variant="secondary"
+              className="me-1"
+              onClick={() => {
+                setCurrent(e);
+                setShowView(true);
+              }}
+              aria-label="View"
+              icon="eye"
+            />
+            <Button
+              size="sm"
+              variant="primary"
+              className="me-1"
+              onClick={() => openEdit(e)}
+              aria-label="Edit"
+              icon="pencil"
+            />
+            <Button
+              size="sm"
+              variant="danger"
+              onClick={() => confirmDelete(e)}
+              aria-label="Delete"
+              icon="trash"
+            />
+          </>
+        )}
+      />
+      <nav aria-label="Page navigation" className="mt-3">
+        <ul className="pagination justify-content-end">
+          <li className={`page-item ${page === 1 ? 'disabled' : ''}`}>
+            <button className="page-link" onClick={() => setPage(page - 1)} aria-label="Previous">
+              &laquo;
+            </button>
+          </li>
+          {Array.from({ length: totalPages }, (_, i) => (
+            <li key={i} className={`page-item ${page === i + 1 ? 'active' : ''}`}>
+              <button className="page-link" onClick={() => setPage(i + 1)}>{i + 1}</button>
+            </li>
+          ))}
+          <li className={`page-item ${page === totalPages ? 'disabled' : ''}`}>
+            <button className="page-link" onClick={() => setPage(page + 1)} aria-label="Next">
+              &raquo;
+            </button>
+          </li>
+        </ul>
+      </nav>
+
+      <Modal
+        show={showForm}
+        title={current.id ? 'Edit Employee' : 'Add Employee'}
+        onClose={() => setShowForm(false)}
+        footer={
+          <>
+            <Button variant="secondary" onClick={() => setShowForm(false)} aria-label="Cancel">
+              Cancel
+            </Button>
+            <Button variant="primary" onClick={saveEmployee} aria-label="Save" className="ms-2">
+              Save
+            </Button>
+          </>
+        }
+      >
+        <FormInput label="Name" icon="person" value={current.name} onChange={(v) => setCurrent({ ...current, name: v })} required />
+        <FormInput label="Email" icon="envelope" type="email" value={current.email} onChange={(v) => setCurrent({ ...current, email: v })} required />
+        <FormInput label="Phone" icon="telephone" value={current.phone} onChange={(v) => setCurrent({ ...current, phone: v })} pattern="\\d{10}" required />
+      </Modal>
+
+      <Modal
+        show={showDelete}
+        title="Confirm Delete"
+        onClose={() => setShowDelete(false)}
+        footer={
+          <>
+            <Button variant="secondary" onClick={() => setShowDelete(false)} aria-label="Cancel">
+              Cancel
+            </Button>
+            <Button variant="danger" onClick={deleteEmployee} aria-label="Confirm delete" className="ms-2">
+              Delete
+            </Button>
+          </>
+        }
+      >
+        Are you sure you want to delete {current.name}?
+      </Modal>
+
+      <Modal show={showView} title="Employee" onClose={() => setShowView(false)}>
+        <p><strong>Name:</strong> {current.name}</p>
+        <p><strong>Email:</strong> {current.email}</p>
+        <p><strong>Phone:</strong> {current.phone}</p>
+      </Modal>
+    </div>
+  );
+}

--- a/kolme-react/src/pages/LeaveRequests.jsx
+++ b/kolme-react/src/pages/LeaveRequests.jsx
@@ -1,0 +1,11 @@
+export default function LeaveRequests() {
+  return (
+    <div className="container-fluid">
+      <h1 className="my-4 border-bottom pb-2">Leave Requests</h1>
+      <p>
+        Manage leave requests
+        <i className="bi bi-info-circle ms-1" aria-label="Leave info" title="Track employee leave requests"></i>
+      </p>
+    </div>
+  );
+}

--- a/kolme-react/src/pages/Login.jsx
+++ b/kolme-react/src/pages/Login.jsx
@@ -1,0 +1,68 @@
+import { useContext, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AuthContext } from '../contexts/AuthContext';
+import FormInput from '../components/common/FormInput';
+import Spinner from '../components/common/Spinner';
+import Button from '../components/common/Button';
+import { showToast } from '../components/common/ToastMessage';
+import api from '../api';
+
+export default function Login() {
+  const { login } = useContext(AuthContext);
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    try {
+      const res = await api.post('/login', { email, password });
+      login(res.data.token);
+      navigate('/');
+    } catch (err) {
+      showToast('Invalid credentials', 'error');
+    }
+    setLoading(false);
+  };
+
+  const valid = email && password;
+
+  return (
+    <div className="d-flex justify-content-center align-items-center min-vh-100 bg-light">
+      <form className="card p-4" onSubmit={handleSubmit} style={{ minWidth: '320px' }}>
+        <h1 className="h4 mb-3 text-center">Login</h1>
+        <FormInput
+          label="Email"
+          icon="envelope"
+          type="email"
+          value={email}
+          onChange={setEmail}
+          required
+          autoFocus
+        />
+        <FormInput
+          label="Password"
+          icon="lock"
+          type="password"
+          value={password}
+          onChange={setPassword}
+          required
+          pattern=".{6,}"
+        />
+        <Button
+          type="submit"
+          className="w-100"
+          variant="primary"
+          icon="box-arrow-in-right"
+          disabled={!valid || loading}
+          aria-label="Login"
+        >
+          {loading ? 'Logging in...' : 'Login'}
+        </Button>
+        {loading && <Spinner />}
+      </form>
+    </div>
+  );
+}

--- a/kolme-react/src/pages/Modules.jsx
+++ b/kolme-react/src/pages/Modules.jsx
@@ -1,0 +1,11 @@
+export default function Modules() {
+  return (
+    <div className="container-fluid">
+      <h1 className="my-4 border-bottom pb-2">Modules</h1>
+      <p>
+        Application modules
+        <i className="bi bi-info-circle ms-1" aria-label="Modules info" title="Modules available in the system"></i>
+      </p>
+    </div>
+  );
+}

--- a/kolme-react/src/pages/Roles.jsx
+++ b/kolme-react/src/pages/Roles.jsx
@@ -1,0 +1,11 @@
+export default function Roles() {
+  return (
+    <div className="container-fluid">
+      <h1 className="my-4 border-bottom pb-2">Roles</h1>
+      <p>
+        Manage user roles
+        <i className="bi bi-info-circle ms-1" aria-label="Roles info" title="Roles define user permissions"></i>
+      </p>
+    </div>
+  );
+}

--- a/kolme-react/src/styles/custom.css
+++ b/kolme-react/src/styles/custom.css
@@ -1,0 +1,34 @@
+body {
+  background-color: #f8f9fa;
+}
+
+.sidebar {
+  width: 200px;
+}
+
+.sidebar.collapsed {
+  width: 0;
+  overflow: hidden;
+}
+
+@media (max-width: 767px) {
+  .sidebar {
+    position: absolute;
+    z-index: 1000;
+    height: 100vh;
+  }
+}
+
+@media (max-width: 575px) {
+  .table-card tbody tr {
+    display: block;
+    margin-bottom: 1rem;
+  }
+  .table-card td,
+  .table-card th {
+    display: block;
+  }
+  .table-card thead {
+    display: none;
+  }
+}

--- a/kolme-react/vite.config.js
+++ b/kolme-react/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- add `Button` component for consistent icon buttons
- switch login and employee pages to use the new component
- integrate button usage in action modals and list actions
- address comments: remove duplicate CDN imports, use API helper, add validation examples

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686b5bfbcaa8832a8d8f0612fa0b3159